### PR TITLE
feat(core): add clearing log statements action

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ See [RECIPES](https://github.com/Goose97/timber.nvim/blob/main/doc/RECIPES.md) g
 
 ## Usage
 
-`timber.nvim` has two core operations: inserting log statements and capturing log results.
-
 ### Insert log statements
 
 There are two kinds of log statements:
@@ -108,6 +106,22 @@ The content of the log statement is specified via templates. See [`:h timber.nvi
     local foo = 1
     print("LOG 1 foo", foo)
 ```
+
+### Clear log statements
+
+Clear all log statements in the current buffer:
+
+```lua
+    require("timber.actions").clear_log_statements({ global = false })
+```
+
+or from all buffers:
+
+```lua
+    require("timber.actions").clear_log_statements({ global = true })
+```
+
+Be aware of [potential limitations](https://github.com/Goose97/timber.nvim/blob/main/doc/timber.nvim.txt).
 
 ### Capture log results
 

--- a/doc/timber.nvim.txt
+++ b/doc/timber.nvim.txt
@@ -150,6 +150,7 @@ Users can invoke actions via the API. Action APIs are defined in the
   :h timber.actions.insert_log
   :h timber.actions.insert_batch_log
   :h timber.actions.add_log_targets_to_batch
+  :h timber.actions.clear_log_statements
 
 
 actions.insert_log({opts})                       *timber.actions.insert_log()*
@@ -224,7 +225,7 @@ actions.add_log_targets_to_batch({opts})          *timber.actions.add_log_target
     |timber.actions.insert_batch_log|
 
 
-actions.get_batch_size({opts})               *timber.actions.get_batch_size()*
+actions.get_batch_size()                     *timber.actions.get_batch_size()*
 
   Get the number of log targets in the batch.
 
@@ -232,9 +233,29 @@ actions.get_batch_size({opts})               *timber.actions.get_batch_size()*
     - integer
 
 
-actions.clear_batch({opts})                     *timber.actions.clear_batch()*
+actions.clear_batch()                           *timber.actions.clear_batch()*
 
   Clear all log targets in the batch.
+
+
+actions.clear_log_statements({opts})   *timber.actions.clear_log_statements()*
+
+  Clear all log statements in the current buffer or all buffers.
+
+  This API has some limitations:
+    - It might not work well with code formatters. The code
+      formatter can break the log statements into multiple lines and we
+      have no mechanism to keep track of them.
+    - With `global = true`, we will clear all buffers, but not all files. Which
+      means files that you haven't loaded won't be cleared.
+
+  Parameters: ~
+    {opts} (table)  options to pass to the action
+
+  Options: ~
+    {global}            (boolean)         whether to clear all buffers (true)
+                                          or just the current one (false).
+					  Default: false
 
 ==============================================================================
 3. Watchers                                             *timber.nvim-watchers*

--- a/lua/timber.lua
+++ b/lua/timber.lua
@@ -14,11 +14,10 @@ local M = {}
 ---@param config Timber.InitConfig?
 M.setup = function(config)
   config_mod.setup(config)
-
   actions.setup()
   highlight.setup()
-
   buffers.setup()
+
   if config_mod.config.log_watcher.enabled then
     watcher.setup(config_mod.config.log_watcher.sources)
   end

--- a/tests/timber/timber_buffers_spec.lua
+++ b/tests/timber/timber_buffers_spec.lua
@@ -51,8 +51,8 @@ describe("timber.buffers autocmd", function()
         expected = function()
           -- Internally, we add the placeholder in the next tick using vim.schedule, hence the wait
           helper.wait(20)
-          assert.is.Not.Nil(buffers.log_placeholders[id1])
-          assert.is.Not.Nil(buffers.log_placeholders[id2])
+          assert.is.Not.Nil(buffers.log_placeholders:get(id1))
+          assert.is.Not.Nil(buffers.log_placeholders:get(id2))
         end,
       })
     end)
@@ -83,8 +83,8 @@ describe("timber.buffers autocmd", function()
             helper.wait(20)
           end,
           expected = function()
-            assert.is.Nil(buffers.log_placeholders[id1])
-            assert.is.Not.Nil(buffers.log_placeholders[id2])
+            assert.is.Nil(buffers.log_placeholders:get(id1))
+            assert.is.Not.Nil(buffers.log_placeholders:get(id2))
 
             assert.equals(#get_extmarks(0), 0)
             assert.equals(#get_extmarks(1), 1)
@@ -116,8 +116,8 @@ describe("timber.buffers autocmd", function()
             helper.wait(20)
           end,
           expected = function()
-            assert.is.Nil(buffers.log_placeholders[id3])
-            assert.is.Nil(buffers.log_placeholders[id4])
+            assert.is.Nil(buffers.log_placeholders:get(id3))
+            assert.is.Nil(buffers.log_placeholders:get(id4))
 
             assert.equals(#get_extmarks(0), 0)
             assert.equals(#get_extmarks(1), 0)
@@ -148,8 +148,8 @@ describe("timber.buffers autocmd", function()
             helper.wait(20)
           end,
           expected = function()
-            assert.is.Not.Nil(buffers.log_placeholders[id1])
-            assert.is.Not.Nil(buffers.log_placeholders[id2])
+            assert.is.Not.Nil(buffers.log_placeholders:get(id1))
+            assert.is.Not.Nil(buffers.log_placeholders:get(id2))
 
             assert.equals(#get_extmarks(1), 1)
             assert.equals(#get_extmarks(2), 1)
@@ -174,7 +174,7 @@ describe("timber.buffers autocmd", function()
             helper.wait(20)
           end,
           expected = function()
-            assert.is.Nil(buffers.log_placeholders[id])
+            assert.is.Nil(buffers.log_placeholders:get(id))
 
             assert.equals(#get_extmarks(1), 0)
           end,
@@ -247,7 +247,7 @@ describe("timber.buffers.new_log_placeholder", function()
     local id = watcher.generate_unique_id()
     buffers.new_log_placeholder({ id = id, bufnr = 1, line = 1, entries = {} })
 
-    assert.is.Not.Nil(buffers.log_placeholders[id])
+    assert.is.Not.Nil(buffers.log_placeholders:get(id))
   end)
 
   it("attaches to the buffer and reacts to buffer changes", function()
@@ -267,8 +267,8 @@ describe("timber.buffers.new_log_placeholder", function()
       expected = function()
         -- Internally, we add the placeholder in the next tick using vim.schedule, hence the wait
         helper.wait(20)
-        assert.is.Nil(buffers.log_placeholders.foo)
-        assert.is.Not.Nil(buffers.log_placeholders[id])
+        assert.is.Nil(buffers.log_placeholders:get("foo"))
+        assert.is.Not.Nil(buffers.log_placeholders:get(id))
       end,
     })
   end)


### PR DESCRIPTION
Closes #3

## What happened

Added an API to clear all log statements from the current buffer (or all buffers)

```lua
require("timber.actions").clear_log_statements({ global = false }) -- true to clear all buffers
```