### PR TITLE
docs: fix some plugin comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ See how to setup syntax highlighting for the float buffer in [RECIPES](https://g
 
 - More mature plugin: support more languages and has fallback heuristic for non-supported languages.
 - Has more features: prompt users to choose expressions to print, print in insert mode
-- Does not use Treesitter to power log
+- Logging mechanism does not use Treesitter as much as timber.nvim
 
 </details>
 
@@ -394,8 +394,7 @@ See how to setup syntax highlighting for the float buffer in [RECIPES](https://g
 [Repo](https://github.com/chrisgrieser/nvim-chainsaw)
 
 - Comes with many built-in commands: objectLog, typeLog, assertLog, etc
-- Can not customize log statements content
-- Does not use Treesitter to power log
+- Logging mechanism does not use Treesitter as much as timber.nvim
 
 </details>
 


### PR DESCRIPTION
Hey, dev of nvim-chainsaw here.

Congratz on the plugin, it does have some really nice features I haven't even thought about.

Just wanted to make a few minor corrections in the comparison of plugin features. (nvim-chainsaw as well as debugprint.nvim both also use treesitter, though not in an as sophisticated way as you do; chainsaw also allows full customization of log statements.)

You can also [have a look here](https://github.com/chrisgrieser/nvim-chainsaw?tab=readme-ov-file#comparison-with-similar-plugins), where I also compared some features of our plugins. Feel free to make a PR as well, in case I have overlooked something!