### PR TITLE
fix(actions): unwrap match capture array on nvim 0.11+ in make-logable-range!

### DIFF
--- a/lua/timber/actions/treesitter.lua
+++ b/lua/timber/actions/treesitter.lua
@@ -211,6 +211,11 @@ function M.setup()
     ---@type TSNode
     local node = match[capture_id]
 
+    -- Breaking changes: https://github.com/neovim/neovim/pull/30193
+    if vim.fn.has("nvim-0.11") == 1 then
+      node = node[1]
+    end
+
     -- Get the adjustment values from the predicate arguments
     local start_adjust = tonumber(predicate[4]) or 0
     local end_adjust = tonumber(predicate[5]) or 0


### PR DESCRIPTION
## Summary

The `make-logable-range!` directive in `lua/timber/actions/treesitter.lua` crashes on Neovim 0.11+ when inserting any log statement, because it treats `match[capture_id]` as a `TSNode` and calls `:range()` directly on it. Since [neovim/neovim#30193](https://github.com/neovim/neovim/pull/30193) (shipped in 0.11), `query:iter_matches` returns capture values as arrays of nodes, so the value is actually `{ TSNode }` and the `:range` method lookup returns nil:

```
E5108: Lua: .../timber/actions/treesitter.lua:219: attempt to call method 'range' (a nil value)
stack traceback:
	.../timber/actions/treesitter.lua:219: in function 'handler'
	...nvim/runtime/lua/vim/treesitter/query.lua:868: in function '_apply_directives'
	...nvim/runtime/lua/vim/treesitter/query.lua:1089: in function '(for generator)'
	.../timber/actions/treesitter.lua:76: in function 'query_log_target_containers'
```

The same file already handles this unwrap in two other places - `query_log_target_container` (lines 79-82) and `get_match_node` (lines 230-233) - but the `make-logable-range!` directive handler was missed.

This PR applies the same minimal `vim.fn.has(\"nvim-0.11\")` guard to the directive handler.

Fixes #47.

## Changes

- Add the nvim-0.11+ capture-array unwrap inside the `make-logable-range!` directive registration, matching the pattern already used elsewhere in the file.

## Test plan

- [x] On Neovim 0.12.2 nightly, with the fix, `glj` / `glk` / `glo` / `glb` insert log statements with no error
- [x] No regression on the existing inline pattern (same `vim.fn.has(\"nvim-0.11\")` check, same `node = node[1]` unwrap)
- [ ] Maintainer to confirm behavior on Neovim 0.10 (the guard is conditional, so 0.10 path is unchanged)